### PR TITLE
Delay system-init execution on first boot

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -43,6 +43,7 @@ $event = "system-init";
 
 event_actions($event, qw(
               nethserver-apu-leds-start 000
+	      nethserver-box-wait-udev  001
               nethserver-apu-leds-stop 99
               nethserver-box-shutdown 999
 ));

--- a/root/etc/e-smith/events/actions/nethserver-box-wait-udev
+++ b/root/etc/e-smith/events/actions/nethserver-box-wait-udev
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Wait until udev has done it's job, then start the real system-init procedure.
+# Udev must not be able to create records inside the networks db before the system-init has run.
+#
+
+config=$(/usr/libexec/nethserver/nic-info)
+
+while true
+do
+    sleep 5
+    last_config=$(/usr/libexec/nethserver/nic-info)
+    if [ -n "$last_config" ] && [ "$config" == "$last_config" ] ; then
+        break
+    else
+        config=$last_config
+    fi
+done
+
+echo "[NOTICE] Ready to start system-init"


### PR DESCRIPTION
Avoid race condition with systemd-udev.

Nethesis/dev#5253