### PR TITLE
Remove useless hostonly dracut option

### DIFF
--- a/root/etc/dracut.conf.d/box_hostonly.conf
+++ b/root/etc/dracut.conf.d/box_hostonly.conf
@@ -1,2 +1,0 @@
-# build initrd only to boot current hardware
-hostonly="yes"


### PR DESCRIPTION
From `man dracut`:

>  On RHEL-7 the hostonly mode is the default mode. Generic "non-hostonly" images are created, if the dracut-config-generic rpm is installed. The rescue kernel entry in the bootloader menu is also a generic image.

